### PR TITLE
Use library constants in binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ src/
 ├── llm.rs               # 🧠 Core LLM implementation and training logic
 ├── lib.rs               # 📚 Library exports and constants
 ├── transformer.rs       # 🔄 Transformer block (attention + feed-forward)
-├── self_attention.rs    # 👀 Multi-head self-attention mechanism  
+├── self_attention.rs    # 👀 Multi-head self-attention mechanism
 ├── feed_forward.rs      # ⚡ Position-wise feed-forward networks
 ├── embeddings.rs        # 📊 Token embedding layer
 ├── output_projection.rs # 🎰 Final linear layer for vocabulary predictions
@@ -80,13 +80,13 @@ The implementation includes two training phases:
 
 ```bash
 # Clone and run
-git clone https://github.com/tekaratzas/RustGPT.git 
+git clone https://github.com/tekaratzas/RustGPT.git
 cd RustGPT
 cargo run
 
 # The model will:
 # 1. Build vocabulary from training data
-# 2. Pre-train on factual statements (100 epochs)  
+# 2. Pre-train on factual statements (100 epochs)
 # 3. Instruction-tune on conversational data (100 epochs)
 # 4. Enter interactive mode for testing
 ```
@@ -107,9 +107,9 @@ Model output: Rain is caused by water vapor in clouds condensing into droplets t
 
 ### Model Configuration
 - **Vocabulary Size**: Dynamic (built from training data)
-- **Embedding Dimension**: 32 (defined by `EMBEDDING_DIM` in `src/lib.rs`)
-- **Hidden Dimension**: 32 (defined by `HIDDEN_DIM` in `src/lib.rs`)
-- **Max Sequence Length**: 40 tokens (defined by `MAX_SEQ_LEN` in `src/lib.rs`)
+- **Embedding Dimension**: 80 (defined by `EMBEDDING_DIM` in `src/lib.rs`)
+- **Hidden Dimension**: 128 (defined by `HIDDEN_DIM` in `src/lib.rs`)
+- **Max Sequence Length**: 256 tokens (defined by `MAX_SEQ_LEN` in `src/lib.rs`)
 - **Architecture**: 3 Transformer blocks + embeddings + output projection
 
 ### Training Details
@@ -196,6 +196,6 @@ Contributions are welcome! This project is perfect for learning and experimentat
 - 🔥 **Intermediate**: Beam search, positional encodings, training checkpoints
 - ⚡ **Advanced**: Multi-head attention, layer parallelization, custom optimizations
 
-Questions? Open an issue or start a discussion! 
+Questions? Open an issue or start a discussion!
 
-No PyTorch, TensorFlow, or Candle - just pure Rust and linear algebra! 
+No PyTorch, TensorFlow, or Candle - just pure Rust and linear algebra!

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Model output: Rain is caused by water vapor in clouds condensing into droplets t
 
 ### Model Configuration
 - **Vocabulary Size**: Dynamic (built from training data)
-- **Embedding Dimension**: 80 (defined by `EMBEDDING_DIM` in `src/lib.rs`)
-- **Hidden Dimension**: 128 (defined by `HIDDEN_DIM` in `src/lib.rs`)
-- **Max Sequence Length**: 256 tokens (defined by `MAX_SEQ_LEN` in `src/lib.rs`)
+- **Embedding Dimension**: 128 (defined by `EMBEDDING_DIM` in `src/lib.rs`)
+- **Hidden Dimension**: 256 (defined by `HIDDEN_DIM` in `src/lib.rs`)
+- **Max Sequence Length**: 80 tokens (defined by `MAX_SEQ_LEN` in `src/lib.rs`)
 - **Architecture**: 3 Transformer blocks + embeddings + output projection
 
 ### Training Details

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Model output: Rain is caused by water vapor in clouds condensing into droplets t
 
 ### Model Configuration
 - **Vocabulary Size**: Dynamic (built from training data)
-- **Embedding Dimension**: 128
-- **Hidden Dimension**: 256  
-- **Max Sequence Length**: 80 tokens
+- **Embedding Dimension**: 32 (defined by `EMBEDDING_DIM` in `src/lib.rs`)
+- **Hidden Dimension**: 32 (defined by `HIDDEN_DIM` in `src/lib.rs`)
+- **Max Sequence Length**: 40 tokens (defined by `MAX_SEQ_LEN` in `src/lib.rs`)
 - **Architecture**: 3 Transformer blocks + embeddings + output projection
 
 ### Training Details

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,6 @@ pub use llm::Layer;
 pub use vocab::Vocab;
 
 // Constants
-pub const MAX_SEQ_LEN: usize = 40;
-pub const EMBEDDING_DIM: usize = 32;
-pub const HIDDEN_DIM: usize = 32;
+pub const MAX_SEQ_LEN: usize = 80;
+pub const EMBEDDING_DIM: usize = 128;
+pub const HIDDEN_DIM: usize = 256;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use std::io::Write;
 
-use embeddings::Embeddings;
-use llm::LLM;
-use output_projection::OutputProjection;
-use transformer::TransformerBlock;
-use vocab::Vocab;
+use crate::embeddings::Embeddings;
+use crate::llm::LLM;
+use crate::output_projection::OutputProjection;
+use crate::transformer::TransformerBlock;
+use crate::vocab::Vocab;
+use ::llm::{EMBEDDING_DIM, HIDDEN_DIM, MAX_SEQ_LEN};
 
 mod adam;
 mod embeddings;
@@ -15,11 +16,6 @@ mod output_projection;
 mod self_attention;
 mod transformer;
 mod vocab;
-
-// Use the constants from lib.rs
-const MAX_SEQ_LEN: usize = 80;
-const EMBEDDING_DIM: usize = 128;
-const HIDDEN_DIM: usize = 256;
 
 fn main() {
     // Mock input - test conversational format
@@ -187,6 +183,10 @@ fn main() {
 
     println!("\n=== MODEL INFORMATION ===");
     println!("Network architecture: {}", llm.network_description());
+    println!(
+        "Model configuration -> max_seq_len: {}, embedding_dim: {}, hidden_dim: {}",
+        MAX_SEQ_LEN, EMBEDDING_DIM, HIDDEN_DIM
+    );
 
     println!("\n=== BEFORE TRAINING ===");
     println!("Input: {}", string);

--- a/tests/feed_forward_test.rs
+++ b/tests/feed_forward_test.rs
@@ -46,7 +46,7 @@ fn test_feed_forward_and_backward() {
     // Test forward pass
     let output = feed_forward.forward(&input);
 
-    let grads = Array2::ones((3, HIDDEN_DIM));
+    let grads = Array2::ones((3, EMBEDDING_DIM));
 
     // Test backward pass
     let grad_input = feed_forward.backward(&grads, 0.01);


### PR DESCRIPTION
## Summary
- import the sequence and dimensional constants from the `llm` library crate so the binary stays synchronized
- log the shared model configuration values during startup
- update the README to reflect the centralized constant definitions

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d18261c0d08329a9ae81439c14ecc2